### PR TITLE
Add editor Caching and restoring to avoid getting the base scene dirty

### DIFF
--- a/Packages/LightingTools.LightmapSwitcher/Editor/EditorEvents.cs
+++ b/Packages/LightingTools.LightmapSwitcher/Editor/EditorEvents.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+// ensure class initializer is called whenever scripts recompile
+[InitializeOnLoadAttribute]
+public static class EditorEvents
+{
+    // register an event handler when the class is initialized
+    static EditorEvents()
+    {
+        EditorApplication.playModeStateChanged += PlayModeChange;
+    }
+
+    private static void PlayModeChange(PlayModeStateChange state)
+    {
+        var lightmapData = GameObject.FindObjectOfType<LevelLightmapData>();
+        if (lightmapData != null)
+        {
+                switch (state)
+            {
+                case PlayModeStateChange.EnteredPlayMode:
+                    lightmapData.OnEnteredPlayMode_EditorOnly();
+                    break;
+                case PlayModeStateChange.ExitingPlayMode:
+                    lightmapData.OnExitingPlayMode_EditorOnly();
+                    break;
+            }
+        }
+    }
+}

--- a/Packages/LightingTools.LightmapSwitcher/Editor/EditorEvents.cs.meta
+++ b/Packages/LightingTools.LightmapSwitcher/Editor/EditorEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac617dcf3a329cf43bc605a55094c45a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/LightingTools.LightmapSwitcher/Runtime/LevelLightmapData.cs
+++ b/Packages/LightingTools.LightmapSwitcher/Runtime/LevelLightmapData.cs
@@ -125,6 +125,30 @@ public class LevelLightmapData : MonoBehaviour
         return sphericalHarmonicsArray;
     }
 
+#if UNITY_EDITOR
+
+    // In editor only we cache the baked probe data when entering playmode, and reset it on exit
+    // This negates runtime changes that the LevelLightmapData library creates in the lighting asset loaded into the starting scene 
+
+    UnityEngine.Rendering.SphericalHarmonicsL2[] cachedBakedProbeData = null;
+
+    public void OnEnteredPlayMode_EditorOnly()
+    {
+        cachedBakedProbeData = LightmapSettings.lightProbes.bakedProbes;
+        Debug.Log("Lightmap swtching tool - Caching editor lightProbes");
+    }
+
+    public void OnExitingPlayMode_EditorOnly()
+    {
+        // Only do this cache restore if we have probe data of matching length
+        if (cachedBakedProbeData != null && LightmapSettings.lightProbes.bakedProbes.Length == cachedBakedProbeData.Length)
+        {
+            LightmapSettings.lightProbes.bakedProbes = cachedBakedProbeData;
+            Debug.Log("Lightmap swtching tool - Restoring editor lightProbes");
+        }
+    }
+#endif
+
     IEnumerator SwitchSceneCoroutine(string sceneToUnload, string sceneToLoad)
     {
         AsyncOperation unloadop = null;


### PR DESCRIPTION
Cache scene light probes when entering play mode and apply them back when exiting play mode.
The goal is to avoid dirtying the scene open in the editor.
Improvements suggested and supplied by Larry from Playabl studio, Thank you :)